### PR TITLE
Problem: Adding a babel update site

### DIFF
--- a/org.example.tycho.targetplatform/org.example.tycho.targetplatform.target
+++ b/org.example.tycho.targetplatform/org.example.tycho.targetplatform.target
@@ -28,5 +28,22 @@
 
 	</location>
 
+
+	<!--
+	  We need to add a babel site with the translations of our own bundles. The host bundles for the
+	  these translations do therefore not yet exist.
+	  
+	  To have a public reproducer we simulate the problem by pulling translations for bundles which are
+	  not in the list above.
+	-->
+	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+		<repository location="http://download.eclipse.org/technology/babel/update-site/R0.17.0/2018-12/"/>
+
+		<unit id="org.eclipse.ant.core.nl_de"/>
+		<unit id="org.eclipse.ant.core.nl_fr"/>
+		<unit id="org.eclipse.ant.core.nl_it"/>
+
+	</location>
+
 </locations>
 </target>


### PR DESCRIPTION
We need to add a Babel update site for the translations of our bundles. Obviously the host bundles are not part of the update site itself -- they will be created during the build. Unfortunately this breaks the build:

    [ERROR] Cannot resolve target definition:
    [ERROR]   Software being installed: org.eclipse.ant.core.nl_de 4.10.0.v20190713081526
    [ERROR]   Missing requirement: org.eclipse.ant.core.nl_de 4.10.0.v20190713081526 requires 'osgi.bundle; org.eclipse.ant.core 0.0.0' but it could not be found

(We simulate the problem with the Eclipse babel update site)


