### PR TITLE
Add environment specific artifact

### DIFF
--- a/org.example.tycho.targetplatform/org.example.tycho.targetplatform.target
+++ b/org.example.tycho.targetplatform/org.example.tycho.targetplatform.target
@@ -17,6 +17,7 @@
         <unit id="org.eclipse.equinox.p2.directorywatcher" version="1.2.100.v20180822-1302"/>
         <unit id="org.eclipse.equinox.p2.extensionlocation" version="1.3.100.v20180822-1302"/>
 		<unit id="org.eclipse.equinox.security" version="1.3.0.v20181115-0746"/>
+		<unit id="org.eclipse.equinox.security.win32.x86_64" version="1.1.100.v20180827-1235"/>
 		<unit id="org.eclipse.jface.text" version="3.15.0.v20181119-1708"/>
         <unit id="org.eclipse.ui.console" version="3.8.300.v20181019-1609"/>
 		<unit id="org.eclipse.ui.forms" version="3.7.400.v20181123-1505"/>


### PR DESCRIPTION
We need environment specific artifacts. If we add them to the ```.target``` file we end up with the follwing error:

    [ERROR] Cannot resolve target definition:
    [ERROR]   Problems resolving provisioning plan.:
    [ERROR]      org.eclipse.equinox.security.win32.x86_64 1.1.100.v20180827-1235 cannot be installed in this environment because its filter is not applicable.

Our build is one reactor where we build all bundles (nearly 1000). Then we have a bunch of features/products where we materialize platform specific products (servers, clients). That's why we need to add environment specific bundles for multiple platforms to our target platform.

It looks like it works when the environment specific bundles are referenced by a feature in the target platform. Unfortunately we need more specific bundles without pulling a whole feature in.